### PR TITLE
refactor!: rename to `@capawesome/capacitor-managed-configurations`

### DIFF
--- a/CapawesomeCapacitorManagedConfigurations.podspec
+++ b/CapawesomeCapacitorManagedConfigurations.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name = 'RobingenzCapacitorManagedConfigurations'
+  s.name = 'CapawesomeCapacitorManagedConfigurations'
   s.version = package['version']
   s.summary = package['description']
   s.license = package['license']
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author = package['author']
   s.source = { :git => package['repository']['url'], :tag => s.version.to_s }
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
-  s.ios.deployment_target  = '12.0'
+  s.ios.deployment_target  = '13.0'
   s.dependency 'Capacitor'
   s.swift_version = '5.1'
 end

--- a/README.md
+++ b/README.md
@@ -1,20 +1,18 @@
 <p align="center"><br><img src="https://user-images.githubusercontent.com/236501/85893648-1c92e880-b7a8-11ea-926d-95355b8175c7.png" width="128" height="128" /></p>
 <h3 align="center">Managed Configuration</h3>
-<p align="center"><strong><code>@robingenz/capacitor-managed-configurations</code></strong></p>
+<p align="center"><strong><code>@capawesome/capacitor-managed-configurations</code></strong></p>
 <p align="center">
   Capacitor plugin to access managed configuration settings.
 </p>
 
 <p align="center">
   <img src="https://img.shields.io/maintenance/yes/2022?style=flat-square" />
-  <a href="https://github.com/robingenz/capacitor-managed-configurations/actions?query=workflow%3A%22CI%22"><img src="https://img.shields.io/github/workflow/status/robingenz/capacitor-managed-configurations/CI/main?style=flat-square" /></a>
-  <a href="https://www.npmjs.com/package/@robingenz/capacitor-managed-configurations"><img src="https://img.shields.io/npm/l/@robingenz/capacitor-managed-configurations?style=flat-square" /></a>
+  <a href="https://github.com/capawesome-team/capacitor-managed-configurations/actions?query=workflow%3A%22CI%22"><img src="https://img.shields.io/github/workflow/status/capawesome-team/capacitor-managed-configurations/CI/main?style=flat-square" /></a>
+  <a href="https://www.npmjs.com/package/@capawesome/capacitor-managed-configurations"><img src="https://img.shields.io/npm/l/@capawesome/capacitor-managed-configurations?style=flat-square" /></a>
 <br>
-  <a href="https://www.npmjs.com/package/@robingenz/capacitor-managed-configurations"><img src="https://img.shields.io/npm/dw/@robingenz/capacitor-managed-configurations?style=flat-square" /></a>
-  <a href="https://www.npmjs.com/package/@robingenz/capacitor-managed-configurations"><img src="https://img.shields.io/npm/v/@robingenz/capacitor-managed-configurations?style=flat-square" /></a>
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-<a href="#contributors-"><img src="https://img.shields.io/badge/all%20contributors-1-orange?style=flat-square" /></a>
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
+  <a href="https://www.npmjs.com/package/@capawesome/capacitor-managed-configurations"><img src="https://img.shields.io/npm/dw/@capawesome/capacitor-managed-configurations?style=flat-square" /></a>
+  <a href="https://www.npmjs.com/package/@capawesome/capacitor-managed-configurations"><img src="https://img.shields.io/npm/v/@capawesome/capacitor-managed-configurations?style=flat-square" /></a>
+  <a href="https://github.com/capawesome-team"><img src="https://img.shields.io/badge/part%20of-capawesome-%234f46e5?style=flat-square" /></a>
 </p>
 
 ## Maintainers
@@ -23,10 +21,18 @@
 | ---------- | ----------------------------------------- | --------------------------------------------- |
 | Robin Genz | [robingenz](https://github.com/robingenz) | [@robin_genz](https://twitter.com/robin_genz) |
 
+## Sponsors
+
+This is an MIT-licensed open source project. 
+It can grow thanks to the support by these awesome people. 
+If you'd like to join them, please read more [here](https://github.com/sponsors/capawesome-team).  
+
+<!-- sponsors --><!-- sponsors -->
+
 ## Installation
 
 ```bash
-npm install @robingenz/capacitor-managed-configurations
+npm install @capawesome/capacitor-managed-configurations
 npx cap sync
 ```
 
@@ -45,7 +51,7 @@ A working example can be found here: [robingenz/capacitor-plugin-demo](https://g
 ## Usage
 
 ```typescript
-import { ManagedConfigurations } from '@robingenz/capacitor-managed-configurations';
+import { ManagedConfigurations } from '@capawesome/capacitor-managed-configurations';
 
 const getString = async () => {
   const result = await ManagedConfigurations.getString({ key: 'server_url' });
@@ -160,8 +166,8 @@ On **iOS**, you need to install the app as a [managed app](https://support.apple
 
 ## Changelog
 
-See [CHANGELOG.md](https://github.com/robingenz/capacitor-managed-configurations/blob/master/CHANGELOG.md).
+See [CHANGELOG.md](https://github.com/capawesome-team/capacitor-managed-configurations/blob/master/CHANGELOG.md).
 
 ## License
 
-See [LICENSE](https://github.com/robingenz/capacitor-managed-configurations/blob/master/LICENSE).
+See [LICENSE](https://github.com/capawesome-team/capacitor-managed-configurations/blob/master/LICENSE).

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="dev.robingenz.capacitorjs.plugins.managedconfigurations">
+    package="io.capawesome.capacitorjs.plugins.managedconfigurations">
 </manifest>

--- a/android/src/main/java/io/capawesome/capacitorjs/plugins/managedconfigurations/ManagedConfigurations.java
+++ b/android/src/main/java/io/capawesome/capacitorjs/plugins/managedconfigurations/ManagedConfigurations.java
@@ -1,4 +1,4 @@
-package dev.robingenz.capacitorjs.plugins.managedconfigurations;
+package io.capawesome.capacitorjs.plugins.managedconfigurations;
 
 import android.content.RestrictionsManager;
 import android.os.Bundle;

--- a/android/src/main/java/io/capawesome/capacitorjs/plugins/managedconfigurations/ManagedConfigurationsPlugin.java
+++ b/android/src/main/java/io/capawesome/capacitorjs/plugins/managedconfigurations/ManagedConfigurationsPlugin.java
@@ -1,4 +1,4 @@
-package dev.robingenz.capacitorjs.plugins.managedconfigurations;
+package io.capawesome.capacitorjs.plugins.managedconfigurations;
 
 import android.content.res.Configuration;
 import com.getcapacitor.JSObject;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,22 @@
 {
-  "name": "@robingenz/capacitor-managed-configurations",
+  "name": "@capawesome/capacitor-managed-configurations",
   "version": "0.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@robingenz/capacitor-managed-configurations",
+      "name": "@capawesome/capacitor-managed-configurations",
       "version": "0.1.4",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/capawesome-team/"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/capawesome"
+        }
+      ],
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@robingenz/capacitor-managed-configurations",
+  "name": "@capawesome/capacitor-managed-configurations",
   "version": "0.1.4",
   "description": "Capacitor plugin to access managed configuration settings.",
   "main": "dist/plugin.cjs.js",
@@ -11,17 +11,27 @@
     "android/build.gradle",
     "dist/",
     "ios/Plugin/",
-    "RobingenzCapacitorManagedConfigurations.podspec"
+    "CapawesomeCapacitorManagedConfigurations.podspec"
   ],
   "author": "Robin Genz <mail@robingenz.dev>",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/robingenz/capacitor-managed-configurations.git"
+    "url": "git+https://github.com/capawesome-team/capacitor-managed-configurations.git"
   },
   "bugs": {
-    "url": "https://github.com/robingenz/capacitor-managed-configurations/issues"
+    "url": "https://github.com/capawesome-team/capacitor-managed-configurations/issues"
   },
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/capawesome-team/"
+    },
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/capawesome"
+    }
+  ],
   "keywords": [
     "capacitor",
     "plugin",
@@ -77,5 +87,8 @@
     "android": {
       "src": "android"
     }
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: This plugin was renamed to `@capawesome/capacitor-managed-configurations`. Please install the new npm package and run `npx cap sync`.